### PR TITLE
Update app.js to fix differerent user vs. org options

### DIFF
--- a/app.js
+++ b/app.js
@@ -71,19 +71,7 @@ async function handleRepoCreated({ octokit, payload }) {
                 },
                 required_status_checks: null,
                 required_conversation_resolution: true,
-                enforce_admins: null,
-                required_pull_request_reviews: {
-                    dismiss_stale_reviews: true,
-                    require_code_owner_reviews: true,
-                    required_approving_review_count: 0,
-                    allow_teams: true,
-                },
-                restrictions: {
-                    users: [],
-                    teams: [],
-                    apps: [],
-                
-                },
+                restrictions: null,
                 required_linear_history: true,
                 allow_force_pushes: false,
                 allow_deletions: false,


### PR DESCRIPTION
This pull request includes changes to the `handleRepoCreated` function in the `app.js` file. The changes simplify the repository settings by removing several restrictions and requirements for pull request reviews and admin enforcement.

The most significant change is the removal of the `required_pull_request_reviews` and `enforce_admins` settings, which previously required code owner reviews, dismissed stale reviews, and enforced admin restrictions. These settings have been replaced with a `null` value for `restrictions`, simplifying the repository settings.